### PR TITLE
Only update config if the config has changed

### DIFF
--- a/dialog/en-us/config.no_change.dialog
+++ b/dialog/en-us/config.no_change.dialog
@@ -1,0 +1,2 @@
+Configuration hasn't changed
+No changes to apply


### PR DESCRIPTION
Keep track of the configuration hash and compare with previous to
determine if anything has changed.

This means a message bus message will only be sent to the config manager if the settings on home.mycroft.ai has been changed.