### PR TITLE
Add ability to set listener via voice

### DIFF
--- a/dialog/en-us/download.started.dialog
+++ b/dialog/en-us/download.started.dialog
@@ -1,0 +1,1 @@
+The download for the listener has begun. This may take anywhere from 20 seconds to 2 minutes.

--- a/dialog/en-us/listener.same.dialog
+++ b/dialog/en-us/listener.same.dialog
@@ -1,0 +1,1 @@
+The listener is already set to {{listener}}.

--- a/dialog/en-us/must.update.dialog
+++ b/dialog/en-us/must.update.dialog
@@ -1,0 +1,1 @@
+Please update your software first.

--- a/dialog/en-us/set.listener.dialog
+++ b/dialog/en-us/set.listener.dialog
@@ -1,0 +1,1 @@
+I've set the listener to {{listener}}.

--- a/vocab/en-us/ListenerKeyword.voc
+++ b/vocab/en-us/ListenerKeyword.voc
@@ -1,0 +1,2 @@
+listener
+wake word listener

--- a/vocab/en-us/ListenerType.voc
+++ b/vocab/en-us/ListenerType.voc
@@ -1,0 +1,5 @@
+pocketsphinx
+precise
+snow boy
+snowboy
+default

--- a/vocab/en-us/SetKeyword.voc
+++ b/vocab/en-us/SetKeyword.voc
@@ -1,0 +1,3 @@
+set
+make
+assign


### PR DESCRIPTION
You can say something like the following:
```
set the listener to precise
change the listener to pocketsphinx
set the listener to snow boy  # Only works if dependencies are installed
```