### PR TITLE
Fix config setting bug and add ability to get listener

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -41,12 +41,17 @@ class ConfigurationSkill(ScheduledSkill):
             .require("ConfigurationSkillUpdateVerb") \
             .build()
         self.register_intent(intent, self.handle_update_intent)
-        intent = IntentBuilder('SetKeyword') \
+        intent = IntentBuilder('SetListenerIntent') \
             .require('SetKeyword') \
             .require('ListenerKeyword') \
             .require('ListenerType') \
             .build()
         self.register_intent(intent, self.handle_set_listener)
+        intent = IntentBuilder('GetListenerIntent') \
+            .require('GetKeyword') \
+            .require('ListenerKeyword') \
+            .build()
+        self.register_intent(intent, self.handle_get_listener)
         self.schedule()
 
     def handle_set_listener(self, message):
@@ -88,6 +93,15 @@ class ConfigurationSkill(ScheduledSkill):
                 return
 
             self.speak_dialog('set.listener', data={'listener': module})
+        except (NameError, SyntaxError, ImportError):
+            self.speak_dialog('must.update')
+
+    def handle_get_listener(self, message):
+        try:
+            from mycroft.configuration.config import Configuration
+            module = Configuration.get()['hotwords']['hey mycroft']['module']
+            self.speak_dialog('get.listener', data={'listener': module})
+
         except (NameError, SyntaxError, ImportError):
             self.speak_dialog('must.update')
 

--- a/__init__.py
+++ b/__init__.py
@@ -58,6 +58,19 @@ class ConfigurationSkill(ScheduledSkill):
             module = module.replace('default', 'pocketsphinx')
             config = Configuration.get()
 
+            new_config = {
+                'precise': {
+                    'dist_url': 'http://bootstrap.mycroft.ai/'
+                                'artifacts/static/daily/'
+                },
+                'hotwords': {'hey mycroft': {'module': module}}
+            }
+            user_config = LocalConf(USER_CONFIG)
+            user_config.merge(new_config)
+            user_config.store()
+
+            self.emitter.emit(Message('configuration.updated'))
+
             if module == 'precise':
                 exe_path = expanduser('~/.mycroft/precise/precise-stream')
                 if isfile(exe_path):
@@ -74,18 +87,6 @@ class ConfigurationSkill(ScheduledSkill):
                 self.speak_dialog('listener.same', data={'listener': module})
                 return
 
-            new_config = {
-                'precise': {
-                    'dist_url': 'http://bootstrap.mycroft.ai/'
-                                'artifacts/static/daily/'
-                },
-                'hotwords': {'hey mycroft': {'module': module}}
-            }
-            user_config = LocalConf(USER_CONFIG)
-            user_config.merge(new_config)
-            user_config.store()
-
-            self.emitter.emit(Message('configuration.updated'))
             self.speak_dialog('set.listener', data={'listener': module})
         except (NameError, SyntaxError, ImportError):
             self.speak_dialog('must.update')

--- a/dialog/en-us/get.listener.dialog
+++ b/dialog/en-us/get.listener.dialog
@@ -1,0 +1,2 @@
+The current listener is {{listener}}.
+The listener is set to {{listener}}.

--- a/vocab/en-us/GetKeyword.voc
+++ b/vocab/en-us/GetKeyword.voc
@@ -1,0 +1,3 @@
+what is
+give me
+tell me


### PR DESCRIPTION
Previously, the config assignment was bypassed when the code returned early to speak to the user that the download has started.

This also allows for phrases like `what is the current listener`.
