### PR TITLE
Handle Empty config reply from backend

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -159,7 +159,7 @@ class ConfigurationSkill(ScheduledSkill):
         self.schedule()
 
     def update(self):
-        config = self.api.find_setting()
+        config = self.api.find_setting() or {}
         location = self.api.find_location()
         if location:
             config["location"] = location


### PR DESCRIPTION
In some cases the backend seem to return nothing for the configuration
value (see https://community.mycroft.ai/t/picroft-error-on-configuration-update/2617/4). This is a simple workaround eliminating the error and allowing the location to be updated at least.

The real issue is that the backend returns an empty answer for the configuration (for some reason) while still returning a 200 success http status.