### PR TITLE
if user requests default switch to precise

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -140,7 +140,7 @@ class ConfigurationSkill(MycroftSkill):
             LocalConf, USER_CONFIG, Configuration
         )
         module = message.data['ListenerType'].replace(' ', '')
-        module = module.replace('default', 'pocketsphinx')
+        module = module.replace('default', 'precise')
         name = module.replace('pocketsphinx', 'pocket sphinx')
 
         if self.get_listener() == module:

--- a/test/behave/change-listener.feature
+++ b/test/behave/change-listener.feature
@@ -1,0 +1,13 @@
+Feature: Change the active wake word listening engine
+
+  Scenario Outline: User asks to change the listener
+    Given an english speaking user
+     When the user says "<set the listener to something>"
+     Then "mycroft-configuration" should reply with "I've set the listener to <listener>"
+
+  Examples: set the listener requests
+    | set the listener to something | listener |
+    | set the listener to pocketsphinx | pocket sphinx |
+    | set the listener to precise | precise |
+    | change the wake word engine to pocketsphinx | pocket sphinx |
+    | make it the default listener | precise |


### PR DESCRIPTION
If a user asked to "set the listener to default" the Skill would switch to Pocketsphinx.

Precise is the default for all new installs and vast majority of users.

## To test
"Hey Mycroft, set the listener to default"